### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/terraform-diff.yaml
+++ b/.github/workflows/terraform-diff.yaml
@@ -1,6 +1,8 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: "Terraform Diff"
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:
@@ -36,6 +38,9 @@ jobs:
 
   sync:
     name: Terraform Diff
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: [home-ops-runner] #Backend is stored on local minio with no external ingress
     needs: ["changed-terraform"]
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/vrozaksen/home-ops/security/code-scanning/14](https://github.com/vrozaksen/home-ops/security/code-scanning/14)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily involves reading repository contents, checking out code, and interacting with secrets, the minimal required permissions should be explicitly defined. At the workflow level, we can set `contents: read` as a baseline. For specific jobs that require additional permissions, such as `pull-requests: write` for posting comments, we can define job-specific `permissions` blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
