### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -110,6 +110,8 @@ jobs:
     needs: ["test", "diff"]
     name: Flux Local - Success
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Any jobs failed?
         if: ${{ contains(needs.*.result, 'failure') }}


### PR DESCRIPTION
Potential fix for [https://github.com/vrozaksen/home-ops/security/code-scanning/10](https://github.com/vrozaksen/home-ops/security/code-scanning/10)

To fix the issue, we will add a `permissions` block to the `success` job. Since the job does not require any write permissions, we will set `contents: read` as the minimal permission required. This ensures that the `GITHUB_TOKEN` is restricted to read-only access, reducing the risk of unintended actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
