### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,6 +1,9 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Labeler
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/vrozaksen/home-ops/security/code-scanning/8](https://github.com/vrozaksen/home-ops/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the required permissions. Based on the workflow's functionality, it needs `contents: read` to access the repository's content and `pull-requests: write` to add labels to pull requests. These permissions will be set at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
