### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,6 +1,8 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Renovate
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/vrozaksen/home-ops/security/code-scanning/12](https://github.com/vrozaksen/home-ops/security/code-scanning/12)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required. Based on the actions used in the workflow:
- `contents: read` is required for `actions/checkout` to read the repository contents.
- `contents: write` is required for `renovatebot/github-action` to create pull requests and update dependencies.

The `permissions` block will be added at the root of the workflow to apply to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
