### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -1,5 +1,8 @@
 ---
 name: Image Pull
+permissions:
+  contents: read
+  id-token: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/vrozaksen/home-ops/security/code-scanning/9](https://github.com/vrozaksen/home-ops/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the following permissions are likely needed:

1. `contents: read` - To read repository contents, which is a common requirement for most workflows.
2. `id-token: write` - Required for the `Attest` step, which uses the `gh attestation verify` command.
3. Additional permissions may be added if specific steps require them.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
