### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nas-restart.yaml
+++ b/.github/workflows/nas-restart.yaml
@@ -1,6 +1,8 @@
 ---
   # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
   name: NFS Deployment Restart
+  permissions:
+    contents: read
 
   on:
     workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/vrozaksen/home-ops/security/code-scanning/7](https://github.com/vrozaksen/home-ops/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, it primarily interacts with repository contents (e.g., checking out code) and does not appear to require write permissions. Therefore, we will set `contents: read` as the minimal permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
