### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -1,6 +1,9 @@
 ---
 name: Flux Local
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/vrozaksen/home-ops/security/code-scanning/4](https://github.com/vrozaksen/home-ops/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply minimal permissions (`contents: read`) to all jobs. This ensures that the `filter` and `test` jobs, which do not require write permissions, are restricted to read-only access. The `diff` job already has its own `permissions` block, so it will remain unaffected. This approach adheres to GitHub's best practices and ensures consistency across the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
