### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -13,6 +13,8 @@ jobs:
   filter:
     name: Flux Local - Filter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       changed-files: ${{ steps.changed-files.outputs.changed_files }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/vrozaksen/home-ops/security/code-scanning/1](https://github.com/vrozaksen/home-ops/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `filter` job. Since the job only uses the `bjw-s-labs/action-changed-files` action to determine changed files, it likely only requires `contents: read` permissions. We will explicitly set this minimal permission level for the `filter` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
