### PR TITLE
feat(renovate): scope forgejo job to vrozaksen/* repos

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/jobs/forgejo.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/forgejo.yaml
@@ -4,7 +4,7 @@ kind: RenovateJob
 metadata:
   name: forgejo
 spec:
-  # Empty discoveryFilter = all repos we have access to (all user repos + orgs)
+  discoveryFilter: "vrozaksen/*"
   provider:
     name: forgejo
     endpoint: https://forgejo.vzkn.eu


### PR DESCRIPTION
Mirror the discoveryFilter used by the home-ops (github) job so
autodiscovery is explicitly limited to the vrozaksen user namespace
instead of all accessible repos.