### PR TITLE
fix(renovate): set RENOVATE_AUTODISCOVER_FILTER for forgejo

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/jobs/forgejo.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/forgejo.yaml
@@ -19,6 +19,8 @@ spec:
       value: "true"
     - name: RENOVATE_AUTODISCOVER
       value: "true"
+    - name: RENOVATE_AUTODISCOVER_FILTER
+      value: "vrozaksen/*"
     # Needed to resolve `github>` preset extends + bump datasource rate limits
     # when scanning Forgejo repos. renovate-token secret is refreshed every 30m
     # by the token-refresh CronJob.


### PR DESCRIPTION
## Summary
- `spec.discoveryFilter` on the mogenius RenovateJob only scopes the operator's own view (GUI/webhooks) — it is **not** passed through to the Renovate run itself, so autodiscover was still picking up all 7 Forgejo repos (incl. `ahe-computer-science-*`).
- Set `RENOVATE_AUTODISCOVER_FILTER=vrozaksen/*` directly via `extraEnv` so Renovate filters at the source.

## Test plan
- [ ] Flux reconciles `kubernetes/apps/renovate/renovate-operator/jobs/forgejo.yaml`
- [ ] Next scheduled job logs `Autodiscovered repositories` with only `vrozaksen/*` entries
- [ ] No more onboarding/run activity on `ahe-computer-science-*` repos

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMooqyKX1YnPdNEe7EMQMD)_